### PR TITLE
:users routes changed to show

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,11 @@ Rails.application.routes.draw do
 
   root to: 'pages#home'
 
-  resources :users, only: %i[show] do
-    resources :boats, only: %i[index show new create edit update]
-    resources :bookings, only: %i[index show new create edit update]
+  resources :users, only: %i[show edit update]
+
+  resources :boats do
+    resources :bookings, only: %i[new create]
   end
 
-  resources :boats, only: %i[destroy]
-  resources :bookings, only: %i[destroy]
-
+  resources :bookings, only: %i[index show edit update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   root to: 'pages#home'
 
-  resources :users, only: %i[show edit update]
+  resources :users, only: %i[show profile update]
 
   resources :boats do
     resources :bookings, only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
   devise_for :users
+
   root to: 'pages#home'
-  resources :users, only: %i[show edit update destroy] do
+
+  resources :users, only: %i[show] do
     resources :boats, only: %i[index show new create edit update]
     resources :bookings, only: %i[index show new create edit update]
   end
+
   resources :boats, only: %i[destroy]
   resources :bookings, only: %i[destroy]
+
 end


### PR DESCRIPTION
I change the :users routes to 
`resources :users, only: %i[show]`
Still I think we should take a closer look to the routes again.

The **devise** **gem** creates already the rest of the routes for the users (edit, delete, create).
Before we were creating again those routes with the `resources :user`

This will be the new routes then:
![Screen Shot 2020-07-04 at 22 45 35](https://user-images.githubusercontent.com/56911839/86520732-1657d880-be48-11ea-9a45-9e20973fe084.png)
