### PR TITLE
Add bio, name and placeholders in sign up view

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,17 +8,26 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
+    <%= f.input :name,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "name" },
+                placeholder: "Full name" %>
+    <%= f.input :bio,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "bio" },
+                placeholder: "Write a few words about yourself" %>
     <%= f.input :email,
                 required: true,
                 autofocus: true,
-                input_html: { autocomplete: "email" }%>
+                input_html: { autocomplete: "email" },
+                placeholder: "Email"%>
     <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
+                input_html: { autocomplete: "new-password" },
+                placeholder: "Password" %>
   </div>
 
   <div class="form-actions">


### PR DESCRIPTION
I added the fields for name and bio in the sign up view, as well as some placeholders. We can decide to move bio to some other page at a later time. 
<img width="498" alt="Screenshot 2020-07-06 at 21 07 25" src="https://user-images.githubusercontent.com/62070643/86630187-c9e9d580-bfcc-11ea-89fe-9762721e58cd.png">
