### PR TITLE
change name of column in boats, add selectors in new boat view

### DIFF
--- a/app/controllers/boats_controller.rb
+++ b/app/controllers/boats_controller.rb
@@ -44,6 +44,6 @@ class BoatsController < ApplicationController
   end
 
   def boat_params
-    params.require(:boat).permit(:name, :description, :capacity, :location, :price, :type, :photo)
+    params.require(:boat).permit(:name, :description, :capacity, :location, :price, :category, :photo)
   end
 end

--- a/app/models/boat.rb
+++ b/app/models/boat.rb
@@ -9,5 +9,5 @@ class Boat < ApplicationRecord
   #                                              message: "Please choose the capacity" }
   # validates :location, presence: true
   # validates :price, presence: true, numericality: { message: 'must be a number' }
-  # validates :type, presence: true, inclusion: { in: ['motorboat', 'sailboat'] }
+  # validates :category, presence: true, inclusion: { in: ['motorboat', 'sailboat'] }
 end

--- a/app/views/boats/_form.html.erb
+++ b/app/views/boats/_form.html.erb
@@ -1,10 +1,10 @@
 <%= simple_form_for @boat do |f|%>
   <%= f.input :name %>
   <%= f.input :description %>
-  <%= f.input :capacity %>
+  <%= f.input :capacity, collection: [2, 4, 6] %>
   <%= f.input :location %>
   <%= f.input :price %>
-  <%= f.input :type %>
+  <%= f.input :category, collection: ['motorboat', 'sailboat'] %>
   <%= f.input :photo, as: :file %>
   <!-- we must make the fields allow selection Select2 -->
   <%= f.submit %>

--- a/db/migrate/20200708092951_change_column_name_in_boats_table.rb
+++ b/db/migrate/20200708092951_change_column_name_in_boats_table.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameInBoatsTable < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :boats, :type, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_174131) do
+ActiveRecord::Schema.define(version: 2020_07_08_092951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2020_07_07_174131) do
     t.integer "capacity"
     t.string "location"
     t.integer "price"
-    t.string "type"
+    t.string "category"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
Chihoko was getting an error because the boat type was called type, apparently that name is reserved and should not be used in tables. 

<img width="956" alt="Screenshot 2020-07-07 at 21 17 11" src="https://user-images.githubusercontent.com/62070643/86904335-d9723700-c110-11ea-885b-c798c9194950.png">


So I made a migration to rename it and also prettified the menu in the views to be able to select the boat category in capacity from a drop-down. 