### PR TITLE
fix syntax error

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -7,7 +7,7 @@ class BookingsController < ApplicationController
 
   def index
     @bookings = policy_scope(Booking).order(checkin: :asc)
-
+  end
 
   def new
     @booking = Booking.new


### PR DESCRIPTION
on the process of resolving the conflict, "end" of the index method is mistakenly deleted. I added it. 