### PR TITLE
remove time from the booking index and show page

### DIFF
--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -6,7 +6,7 @@
         <%= cl_image_tag booking.boat.photo.key, height: 300, width: 300, crop: :fill %>
         <h2><%= link_to booking.boat.name, booking_path(booking) %></h2>
         <li>Your booking is: <strong><%= booking.status %></strong></li>
-        <li>From <strong><%= booking.checkin.strftime("%m/%d/%Y") %></strong> -- To <strong><%= booking.checkout.strftime("%m/%d/%Y") %></strong> </li>
+        <li>From <strong><%= booking.checkin.strftime("%d %b") %></strong> -- To <strong><%= booking.checkout.strftime("%d %b") %></strong> </li>
         <li>Total price : <strong><%= booking.booking_price %></strong> EUR</li>
       </div>
     <% end %>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -1,14 +1,14 @@
 <div class="container">
   <h2>Here are your bookings</h2>
-  <% @bookings.each do |booking| %>
-    <% if booking.status == "cancelled" %>
-    <!-- We can differentate canceled booking later with CSS or something -->
-    <% else %>
-      <h2><%= link_to booking.boat.name, booking_path(booking) %></h2>
-      <li><%= cl_image_tag booking.boat.photo.key, height: 200, width: 200, crop: :fill %></li>
-      <li>Your booking is: <%= booking.status %></li>
-      <li><%= booking.checkin.strftime("%m/%d/%Y at %I:%M%p") %> --- <%= booking.checkout.strftime("%m/%d/%Y at %I:%M%p") %> </li>
-      <li><%= booking.booking_price %> EUR</li>
+  <div class="grid-boats">
+    <% @bookings.each do |booking| %>
+      <div>
+        <%= cl_image_tag booking.boat.photo.key, height: 300, width: 300, crop: :fill %>
+        <h2><%= link_to booking.boat.name, booking_path(booking) %></h2>
+        <li>Your booking is: <strong><%= booking.status %></strong></li>
+        <li>From <strong><%= booking.checkin.strftime("%m/%d/%Y") %></strong> -- To <strong><%= booking.checkout.strftime("%m/%d/%Y") %></strong> </li>
+        <li>Total price : <strong><%= booking.booking_price %></strong> EUR</li>
+      </div>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/bookings/show.html.erb
+++ b/app/views/bookings/show.html.erb
@@ -4,8 +4,8 @@
   <ul>
     <li>Your booking is: <%= @booking.status %></li>
     <li>The boat owner is: <%= @booking.boat.user.name %></li>
-    <li>Check in: <%= @booking.checkin.strftime("%m/%d/%Y") %></li>
-    <li>Check out: <%= @booking.checkout.strftime("%m/%d/%Y") %></li>
+    <li>Check in: <%= @booking.checkin.strftime("%d %b") %></li>
+    <li>Check out: <%= @booking.checkout.strftime("%d %b") %></li>
     <li><%= @booking.booking_price %> EUR</li>
   </ul>
 

--- a/app/views/bookings/show.html.erb
+++ b/app/views/bookings/show.html.erb
@@ -4,15 +4,17 @@
   <ul>
     <li>Your booking is: <%= @booking.status %></li>
     <li>The boat owner is: <%= @booking.boat.user.name %></li>
-    <li>Check in: <%= @booking.checkin.strftime("%m/%d/%Y at %I:%M%p") %></li>
-    <li>Check out: <%= @booking.checkout.strftime("%m/%d/%Y at %I:%M%p") %></li>
+    <li>Check in: <%= @booking.checkin.strftime("%m/%d/%Y") %></li>
+    <li>Check out: <%= @booking.checkout.strftime("%m/%d/%Y") %></li>
     <li><%= @booking.booking_price %> EUR</li>
   </ul>
 
+<% unless @booking.status == "cancelled" %>
   <% if policy(@booking).edit? %>
-   <p><%= link_to "Update", edit_booking_path(@booking) %></p>
+   <button type="button" class="btn btn-link"><%= link_to "Update", edit_booking_path(@booking) %></button>
   <% end %>
 
-  <p><%= link_to 'Cancel', booking_path(@booking, booking:{ status:"cancelled" }), method: :patch %></p>
-
+  <button type="button" class="btn btn-link"><%= link_to 'Cancel the booking', booking_path(@booking, booking:{ status:"cancelled" }), method: :patch %></button>
+<% end %>
+  <p><%= link_to 'Back to all bookings', bookings_path %></p>
 </div>


### PR DESCRIPTION
-  removed check-in time and check-out time from the booking index and show page. 
-  implemented the same grid as boat index. 
-  changed the index to display all booking incl. cancelled bookings. 

booking index page
![image](https://user-images.githubusercontent.com/61164812/87233844-6ea05480-c3cb-11ea-9815-095028cdb753.png)


cancelled booking page
No "Update" or "Cancel the booking" buttons
![image](https://user-images.githubusercontent.com/61164812/87233752-a4910900-c3ca-11ea-9a50-bb06d5690fce.png)

pending booking page
![image](https://user-images.githubusercontent.com/61164812/87233755-a78bf980-c3ca-11ea-87d3-9088f9390d40.png)
