### PR TITLE
map boats index position sticky top 72px

### DIFF
--- a/app/views/boats/index.html.erb
+++ b/app/views/boats/index.html.erb
@@ -54,7 +54,7 @@
 
 
   <div id="map-index" class="mt-3"
-     style="width: 100%; height: 600px;"
+     style="width: 100%; height: 600px;position: sticky;top: 72px;"
      data-markers="<%= @markers.to_json %>"
      data-mapbox-api-key='<%= ENV['MAPBOX_API_KEY'] %>'></div>
   </div>


### PR DESCRIPTION
Map sticky to top 72px, right under the navbar while scrolling down.
![Screen Shot 2020-07-18 at 12 52 40](https://user-images.githubusercontent.com/56911839/87851075-99bc0400-c8f5-11ea-8afb-24e1afcc844c.png)
